### PR TITLE
storefront period comparison and insight cards

### DIFF
--- a/src/components/business/Detail.tsx
+++ b/src/components/business/Detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "../ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "../ui/tabs";
 import { Product } from "./Product";
@@ -23,7 +23,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { fetchComparableProducts } from "@/lib/data/utils";
+import { Label } from "../ui/label";
+import { Badge } from "../ui/badge";
+import { fetchBusiness, fetchProducts } from "@/lib/data/utils";
 
 export function priceRange(price_range) {
     if (price_range && price_range.length > 1) {
@@ -35,28 +37,63 @@ export function priceRange(price_range) {
 
 const DetailSection = ({ business, favorites, services, reviews, events }) => {
   const { user } = useAuth();
-  const [selectedService, setSelectedService] = useState(null);
+  const [productDetailOpen, setProductDetailOpen] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState(null);
   const [comparisonOpen, setComparisonOpen] = useState(false);
-  const [comparisons, setComparisons] = useState<any[] | null>(null);
-  const [selectedStoreId, setSelectedStoreId] = useState<string | "all">("all");
-  const [loadingComparisons, setLoadingComparisons] = useState(false);
+  const [selectedService, setSelectedService] = useState(null);
+  const [stores, setStores] = useState<{ id: string; name: string }[]>([]);
+  const [selectedStoreId, setSelectedStoreId] = useState<string>(null);
+  const [storeProducts, setStoreProducts] = useState([]);
+  const [loadingStoreProducts, setLoadingStoreProducts] = useState(false);
+  const [compareWithProduct, setCompareWithProduct] = useState(null);
 
-  const openComparison = async (service: any) => {
-    setSelectedService(service);
+  const openProductDetail = (service) => {
+    setSelectedProduct(service);
+    setProductDetailOpen(true);
+  };
+
+  const openComparisonFromDetail = () => {
+    if (!selectedProduct) return;
+    setSelectedService(selectedProduct);
+    setProductDetailOpen(false);
     setComparisonOpen(true);
-    setLoadingComparisons(true);
+    setSelectedStoreId(business.id);
+    setCompareWithProduct(null);
+    setStoreProducts(services);
+  };
+
+  const loadStores = async () => {
     try {
-      const data = await fetchComparableProducts(service.name);
-      setComparisons(data);
-      // Default to current store
-      setSelectedStoreId(business.id);
-    } catch (error) {
-      console.error("Error fetching comparable products:", error);
-      setComparisons(null);
-    } finally {
-      setLoadingComparisons(false);
+      const data = await fetchBusiness();
+      if (data && data.length > 0) {
+        setStores(data.map((b) => ({ id: b.id, name: b.name })));
+      }
+    } catch (e) {
+      console.error("Error loading stores:", e);
     }
   };
+
+  useEffect(() => {
+    if (comparisonOpen) {
+      if (stores.length === 0) {
+        setStores([{ id: business.id, name: business.name }]);
+        loadStores();
+      }
+    }
+  }, [comparisonOpen]);
+
+  useEffect(() => {
+    if (!comparisonOpen || !selectedStoreId) return;
+    if (selectedStoreId === business.id) {
+      setStoreProducts(services);
+      return;
+    }
+    setLoadingStoreProducts(true);
+    fetchProducts(selectedStoreId)
+      .then((list) => setStoreProducts(list ?? []))
+      .catch(() => setStoreProducts([]))
+      .finally(() => setLoadingStoreProducts(false));
+  }, [comparisonOpen, selectedStoreId, business.id, services]);
 
   
 
@@ -114,7 +151,13 @@ const DetailSection = ({ business, favorites, services, reviews, events }) => {
                   <div className="space-y-4 mb-6">
                     <h4 className="font-medium text-foreground mb-4">Crowd Favorites</h4>
                     {favorites.map((favorite, index) => (
-                      <Product key={index} service={favorite} />
+                      <div
+                        key={favorite.id || index}
+                        onClick={() => openProductDetail(favorite)}
+                        className="cursor-pointer"
+                      >
+                        <Product service={favorite} />
+                      </div>
                     ))}
                   </div>
                   <hr />
@@ -123,7 +166,11 @@ const DetailSection = ({ business, favorites, services, reviews, events }) => {
               <div className="space-y-4">
                 {favorites.length > 0 && <h4 className="font-medium text-foreground my-4">All Services</h4>}
                 {services.map((service, index) => (
-                  <div key={service.id || index} onClick={() => openComparison(service)} className="cursor-pointer">
+                  <div
+                    key={service.id || index}
+                    onClick={() => openProductDetail(service)}
+                    className="cursor-pointer"
+                  >
                     <Product service={service} />
                   </div>
                 ))}
@@ -164,113 +211,187 @@ const DetailSection = ({ business, favorites, services, reviews, events }) => {
         </TabsContent>
       </Tabs>
 
-      {/* Comparison dialog */}
-      {selectedService && (
-        <Dialog open={comparisonOpen} onOpenChange={setComparisonOpen}>
-          <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+      {/* Product detail dialog */}
+      {selectedProduct && (
+        <Dialog open={productDetailOpen} onOpenChange={setProductDetailOpen}>
+          <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
             <DialogHeader>
-              <DialogTitle>Compare prices for {selectedService.name}</DialogTitle>
+              <DialogTitle>{selectedProduct.name}</DialogTitle>
               <DialogDescription>
-                Compare this {selectedService.is_service ? "service" : "product"} across different stores.
+                {business.name} · {selectedProduct.is_service ? "Service" : "Product"}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              {selectedProduct.image && (
+                <img
+                  src={selectedProduct.image}
+                  alt={selectedProduct.name}
+                  className="w-full h-48 object-cover rounded-lg"
+                />
+              )}
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">
+                  {selectedProduct.is_service ? "Service" : "Product"}
+                </Badge>
+              </div>
+              {selectedProduct.description && (
+                <p className="text-sm text-muted-foreground">{selectedProduct.description}</p>
+              )}
+              <div className="flex gap-4 text-sm">
+                <span className="font-semibold text-foreground">
+                  ${Number(selectedProduct.price).toFixed(2)}
+                </span>
+                {selectedProduct.duration && (
+                  <span className="text-muted-foreground">{selectedProduct.duration}</span>
+                )}
+              </div>
+              {selectedProduct.tags && selectedProduct.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {selectedProduct.tags.map((tag, i) => (
+                    <Badge key={i} variant="secondary" className="text-xs">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+              <Button onClick={openComparisonFromDetail} className="w-full">
+                Compare with another item
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Comparison dialog: side-by-side with store dropdown and list */}
+      {selectedService && (
+        <Dialog
+          open={comparisonOpen}
+          onOpenChange={(open) => {
+            setComparisonOpen(open);
+            if (!open) setCompareWithProduct(null);
+          }}
+        >
+          <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Compare items</DialogTitle>
+              <DialogDescription>
+                Compare this item with another from any store. Select a store, then pick an item to compare side by side.
               </DialogDescription>
             </DialogHeader>
 
             <div className="space-y-4">
-              <div className="border border-border rounded-lg p-4">
-                <h3 className="font-semibold text-foreground mb-1">
-                  {selectedService.name} – {business.name}
-                </h3>
-                {selectedService.description && (
-                  <p className="text-sm text-muted-foreground mb-2">
-                    {selectedService.description}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="border border-border rounded-lg p-4">
+                  <h4 className="text-xs font-medium text-muted-foreground mb-1">Selected item</h4>
+                  <h3 className="font-semibold text-foreground mb-1">{selectedService.name}</h3>
+                  <p className="text-xs text-muted-foreground mb-1">{business.name}</p>
+                  {selectedService.description && (
+                    <p className="text-sm text-muted-foreground mb-2">{selectedService.description}</p>
+                  )}
+                  <p className="text-sm">
+                    Price: <span className="font-semibold">${Number(selectedService.price).toFixed(2)}</span>
+                    {selectedService.duration && <> · {selectedService.duration}</>}
                   </p>
-                )}
-                <p className="text-sm text-muted-foreground">
-                  Price: <span className="font-semibold">${selectedService.price.toFixed(2)}</span>
-                  {selectedService.duration && <> • {selectedService.duration}</>}
-                </p>
+                  {selectedService.image && (
+                    <img
+                      src={selectedService.image}
+                      alt={selectedService.name}
+                      className="mt-2 h-24 w-full object-cover rounded"
+                    />
+                  )}
+                </div>
+                <div className="border border-border rounded-lg p-4">
+                  {compareWithProduct ? (
+                    <>
+                      <h4 className="text-xs font-medium text-muted-foreground mb-1">Compare with</h4>
+                      <h3 className="font-semibold text-foreground mb-1">{compareWithProduct.name}</h3>
+                      <p className="text-xs text-muted-foreground mb-1">
+                        {selectedStoreId === business.id ? business.name : stores.find((s) => s.id === selectedStoreId)?.name}
+                      </p>
+                      {compareWithProduct.description && (
+                        <p className="text-sm text-muted-foreground mb-2">{compareWithProduct.description}</p>
+                      )}
+                      <p className="text-sm">
+                        Price: <span className="font-semibold">${Number(compareWithProduct.price).toFixed(2)}</span>
+                        {compareWithProduct.duration && <> · {compareWithProduct.duration}</>}
+                      </p>
+                      {compareWithProduct.image && (
+                        <img
+                          src={compareWithProduct.image}
+                          alt={compareWithProduct.name}
+                          className="mt-2 h-24 w-full object-cover rounded"
+                        />
+                      )}
+                    </>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Select a store and an item below to compare.</p>
+                  )}
+                </div>
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm">Compare with store</Label>
+                <Label className="text-sm">Store to compare with</Label>
                 <Select
-                  value={selectedStoreId}
-                  onValueChange={(val) => setSelectedStoreId(val as string | "all")}
+                  value={selectedStoreId ?? ""}
+                  onValueChange={(val) => {
+                    setSelectedStoreId(val);
+                    setCompareWithProduct(null);
+                  }}
                 >
                   <SelectTrigger className="w-full md:w-64">
-                    <SelectValue placeholder="Select store to compare" />
+                    <SelectValue placeholder="Select store" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Stores</SelectItem>
-                    {comparisons &&
-                      Array.from(
-                        new Map(
-                          comparisons.map((c) => [
-                            c.businesses?.id,
-                            { id: c.businesses?.id, name: c.businesses?.name },
-                          ]),
-                        ).values(),
-                      )
-                        .filter((s) => s.id)
-                        .map((store) => (
-                          <SelectItem key={store.id} value={store.id}>
-                            {store.name}
-                          </SelectItem>
-                        ))}
+                    {stores.map((store) => (
+                      <SelectItem key={store.id} value={store.id}>
+                        {store.name}
+                        {store.id === business.id ? " (this store)" : ""}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
 
-              <div className="space-y-3">
-                <h4 className="font-semibold text-foreground">Comparable offers</h4>
-                {loadingComparisons ? (
-                  <p className="text-sm text-muted-foreground">Loading comparisons...</p>
-                ) : !comparisons || comparisons.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No comparable products found yet.
-                  </p>
-                ) : (
-                  comparisons
-                    .filter((c) =>
-                      selectedStoreId === "all"
-                        ? true
-                        : c.businesses?.id === selectedStoreId,
-                    )
-                    .sort((a, b) => Number(a.price) - Number(b.price))
-                    .map((c) => (
-                      <div
-                        key={c.id}
-                        className="flex items-start gap-4 p-3 border border-border rounded-lg"
-                      >
-                        {c.images && (
-                          <img
-                            src={Array.isArray(c.images) ? c.images[0] : c.images}
-                            alt={c.product_name}
-                            className="h-16 w-16 rounded-lg object-cover"
-                          />
-                        )}
-                        <div className="flex-1">
-                          <div className="flex items-center justify-between mb-1">
-                            <p className="font-semibold text-foreground">
-                              {c.product_name}
-                            </p>
-                            <span className="text-sm font-semibold text-foreground">
-                              ${Number(c.price).toFixed(2)}
-                            </span>
-                          </div>
-                          <p className="text-xs text-muted-foreground mb-1">
-                            Store: {c.businesses?.name || "Unknown"}
-                          </p>
-                          {c.description && (
-                            <p className="text-sm text-muted-foreground">
-                              {c.description}
-                            </p>
+              {selectedStoreId && (
+                <div className="space-y-2">
+                  <Label className="text-sm">Items from selected store</Label>
+                  {loadingStoreProducts ? (
+                    <p className="text-sm text-muted-foreground">Loading...</p>
+                  ) : storeProducts.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No items in this store.</p>
+                  ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-48 overflow-y-auto">
+                      {storeProducts.map((p) => (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => setCompareWithProduct(p)}
+                          className={`flex items-start gap-2 p-3 border rounded-lg text-left transition-colors ${
+                            compareWithProduct?.id === p.id
+                              ? "border-primary bg-primary/5"
+                              : "border-border hover:bg-muted/50"
+                          }`}
+                        >
+                          {p.image && (
+                            <img
+                              src={p.image}
+                              alt={p.name}
+                              className="h-12 w-12 rounded object-cover shrink-0"
+                            />
                           )}
-                        </div>
-                      </div>
-                    ))
-                )}
-              </div>
+                          <div className="min-w-0 flex-1">
+                            <p className="font-medium text-foreground text-sm truncate">{p.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              ${Number(p.price).toFixed(2)}
+                              {p.duration && ` · ${p.duration}`}
+                            </p>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </DialogContent>
         </Dialog>

--- a/src/components/business/Detail.tsx
+++ b/src/components/business/Detail.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Card, CardContent } from "../ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "../ui/tabs";
 import { Product } from "./Product";
@@ -8,6 +9,21 @@ import { Event } from "./Event";
 import { Clock, MapPin, DollarSign } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { formatHours } from "./Hours";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { fetchComparableProducts } from "@/lib/data/utils";
 
 export function priceRange(price_range) {
     if (price_range && price_range.length > 1) {
@@ -19,6 +35,28 @@ export function priceRange(price_range) {
 
 const DetailSection = ({ business, favorites, services, reviews, events }) => {
   const { user } = useAuth();
+  const [selectedService, setSelectedService] = useState(null);
+  const [comparisonOpen, setComparisonOpen] = useState(false);
+  const [comparisons, setComparisons] = useState<any[] | null>(null);
+  const [selectedStoreId, setSelectedStoreId] = useState<string | "all">("all");
+  const [loadingComparisons, setLoadingComparisons] = useState(false);
+
+  const openComparison = async (service: any) => {
+    setSelectedService(service);
+    setComparisonOpen(true);
+    setLoadingComparisons(true);
+    try {
+      const data = await fetchComparableProducts(service.name);
+      setComparisons(data);
+      // Default to current store
+      setSelectedStoreId(business.id);
+    } catch (error) {
+      console.error("Error fetching comparable products:", error);
+      setComparisons(null);
+    } finally {
+      setLoadingComparisons(false);
+    }
+  };
 
   
 
@@ -85,7 +123,9 @@ const DetailSection = ({ business, favorites, services, reviews, events }) => {
               <div className="space-y-4">
                 {favorites.length > 0 && <h4 className="font-medium text-foreground my-4">All Services</h4>}
                 {services.map((service, index) => (
-                  <Product key={index} service={service} />
+                  <div key={service.id || index} onClick={() => openComparison(service)} className="cursor-pointer">
+                    <Product service={service} />
+                  </div>
                 ))}
               </div>
             </CardContent>
@@ -123,6 +163,118 @@ const DetailSection = ({ business, favorites, services, reviews, events }) => {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* Comparison dialog */}
+      {selectedService && (
+        <Dialog open={comparisonOpen} onOpenChange={setComparisonOpen}>
+          <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Compare prices for {selectedService.name}</DialogTitle>
+              <DialogDescription>
+                Compare this {selectedService.is_service ? "service" : "product"} across different stores.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div className="border border-border rounded-lg p-4">
+                <h3 className="font-semibold text-foreground mb-1">
+                  {selectedService.name} – {business.name}
+                </h3>
+                {selectedService.description && (
+                  <p className="text-sm text-muted-foreground mb-2">
+                    {selectedService.description}
+                  </p>
+                )}
+                <p className="text-sm text-muted-foreground">
+                  Price: <span className="font-semibold">${selectedService.price.toFixed(2)}</span>
+                  {selectedService.duration && <> • {selectedService.duration}</>}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-sm">Compare with store</Label>
+                <Select
+                  value={selectedStoreId}
+                  onValueChange={(val) => setSelectedStoreId(val as string | "all")}
+                >
+                  <SelectTrigger className="w-full md:w-64">
+                    <SelectValue placeholder="Select store to compare" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Stores</SelectItem>
+                    {comparisons &&
+                      Array.from(
+                        new Map(
+                          comparisons.map((c) => [
+                            c.businesses?.id,
+                            { id: c.businesses?.id, name: c.businesses?.name },
+                          ]),
+                        ).values(),
+                      )
+                        .filter((s) => s.id)
+                        .map((store) => (
+                          <SelectItem key={store.id} value={store.id}>
+                            {store.name}
+                          </SelectItem>
+                        ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-3">
+                <h4 className="font-semibold text-foreground">Comparable offers</h4>
+                {loadingComparisons ? (
+                  <p className="text-sm text-muted-foreground">Loading comparisons...</p>
+                ) : !comparisons || comparisons.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No comparable products found yet.
+                  </p>
+                ) : (
+                  comparisons
+                    .filter((c) =>
+                      selectedStoreId === "all"
+                        ? true
+                        : c.businesses?.id === selectedStoreId,
+                    )
+                    .sort((a, b) => Number(a.price) - Number(b.price))
+                    .map((c) => (
+                      <div
+                        key={c.id}
+                        className="flex items-start gap-4 p-3 border border-border rounded-lg"
+                      >
+                        {c.images && (
+                          <img
+                            src={Array.isArray(c.images) ? c.images[0] : c.images}
+                            alt={c.product_name}
+                            className="h-16 w-16 rounded-lg object-cover"
+                          />
+                        )}
+                        <div className="flex-1">
+                          <div className="flex items-center justify-between mb-1">
+                            <p className="font-semibold text-foreground">
+                              {c.product_name}
+                            </p>
+                            <span className="text-sm font-semibold text-foreground">
+                              ${Number(c.price).toFixed(2)}
+                            </span>
+                          </div>
+                          <p className="text-xs text-muted-foreground mb-1">
+                            Store: {c.businesses?.name || "Unknown"}
+                          </p>
+                          {c.description && (
+                            <p className="text-sm text-muted-foreground">
+                              {c.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    ))
+                )}
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/src/components/business/Product.tsx
+++ b/src/components/business/Product.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -14,7 +14,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { z } from "zod";
 import { Product as ProductType } from "@/lib/interfaces";
-import { insertProduct } from "@/lib/data/utils";
+import { insertProduct, updateProduct } from "@/lib/data/utils";
 
 const productSchema = z.object({
   name: z.string().trim().min(1, "Product/Service name is required").max(100),
@@ -239,6 +239,222 @@ const AddProduct = ({ businessId, open, onOpenChange, onSuccess }: AddProductPro
   );
 };
 
+interface EditProductProps {
+  businessId: string;
+  product: ProductType | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+const EditProduct = ({ businessId, product, open, onOpenChange, onSuccess }: EditProductProps) => {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    price: "",
+    duration: "",
+    tags: "",
+    is_service: true,
+    image: null as File | null,
+  });
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (open && product) {
+      setFormData({
+        name: product.name,
+        description: product.description ?? "",
+        price: product.price.toString(),
+        duration: product.duration ?? "",
+        tags: Array.isArray(product.tags) ? product.tags.join(", ") : "",
+        is_service: product.is_service ?? true,
+        image: null,
+      });
+    }
+  }, [open, product]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!product) return;
+
+    try {
+      const validated = productSchema.parse({
+        name: formData.name,
+        description: formData.description || undefined,
+        price: parseFloat(formData.price),
+        duration: formData.duration || undefined,
+        tags: formData.tags || undefined,
+        is_service: formData.is_service,
+        image: formData.image || undefined,
+      });
+
+      setLoading(true);
+
+      const tagsArray = validated.tags
+        ? validated.tags.split(",").map(tag => tag.trim()).filter(tag => tag.length > 0)
+        : [];
+
+      const updatedProduct: ProductType = {
+        ...product,
+        name: validated.name,
+        business_id: businessId,
+        description: validated.description || null,
+        price: validated.price,
+        duration: validated.duration || null,
+        tags: tagsArray.length > 0 ? tagsArray : null,
+        is_service: validated.is_service,
+        image: product.image ?? (validated.image ? validated.image.name : undefined),
+      };
+
+      await updateProduct(updatedProduct, validated.image || undefined);
+
+      toast({
+        title: "Product/Service updated",
+        description: `${validated.is_service ? "Service" : "Product"} has been updated.`,
+      });
+
+      onSuccess();
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        toast({
+          title: "Validation Error",
+          description: error.errors[0].message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: error instanceof Error ? error.message : "Failed to update product/service",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!product) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Product/Service</DialogTitle>
+          <DialogDescription>
+            Update the details of your product or service
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="edit-name">Name *</Label>
+            <Input
+              id="edit-name"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              placeholder="e.g., Box Braids, Haircut, Consultation"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-type">Type *</Label>
+            <div className="flex gap-4">
+              <Button
+                type="button"
+                variant={formData.is_service ? "default" : "outline"}
+                onClick={() => setFormData({ ...formData, is_service: true })}
+              >
+                Service
+              </Button>
+              <Button
+                type="button"
+                variant={!formData.is_service ? "default" : "outline"}
+                onClick={() => setFormData({ ...formData, is_service: false })}
+              >
+                Product
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-description">Description</Label>
+            <Textarea
+              id="edit-description"
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              placeholder="Describe your product or service..."
+              rows={3}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-price">Price ($) *</Label>
+              <Input
+                id="edit-price"
+                type="number"
+                step="0.01"
+                min="0"
+                value={formData.price}
+                onChange={(e) => setFormData({ ...formData, price: e.target.value })}
+                placeholder="0.00"
+                required
+              />
+            </div>
+
+            {formData.is_service && (
+              <div className="space-y-2">
+                <Label htmlFor="edit-duration">Duration</Label>
+                <Input
+                  id="edit-duration"
+                  value={formData.duration}
+                  onChange={(e) => setFormData({ ...formData, duration: e.target.value })}
+                  placeholder="e.g., 2 hours, 30 minutes"
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-tags">Tags</Label>
+            <Input
+              id="edit-tags"
+              value={formData.tags}
+              onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
+              placeholder="e.g., braids, natural hair, quick service"
+            />
+            <p className="text-sm text-muted-foreground">Separate tags with commas</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-image">Image</Label>
+            {product.image && !formData.image && (
+              <p className="text-sm text-muted-foreground mb-1">Current image: shown on listing</p>
+            )}
+            <Input
+              id="edit-image"
+              type="file"
+              accept="image/png, image/jpeg, image/jpg"
+              onChange={(e) => setFormData({ ...formData, image: e.target.files?.[0] || null })}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Saving..." : "Save changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
 const Product = ({service}) => {
     return (
                 <div key={service.id} className="flex items-start justify-between p-4 border border-border rounded-lg hover:bg-muted/50 transition-colors">
@@ -252,4 +468,4 @@ const Product = ({service}) => {
     );
 }
 
-export {AddProduct, Product};
+export { AddProduct, EditProduct, Product };

--- a/src/lib/data/utils.ts
+++ b/src/lib/data/utils.ts
@@ -174,15 +174,22 @@ export async function deleteBusiness(businessId: string, user_id: string): Promi
 /**
  * Fetch product data from the database.
  *
- * @param business - The array of business IDs to fetch products for.
- * @param product_id - ID value used to fetch most popular products
+ * @param business_id - Optional business ID to filter products for a specific business.
+ * @param is_fav - Optional flag to fetch only favorite products.
  * @returns A promise that resolves to an array of product data
  * @throws Error if the fetch operation fails.
  */
 export async function fetchProducts(business_id?: string, is_fav?: boolean): Promise<Product[] | null> {
-    let query = supabase.from('products').select('*').eq('business_id', business_id);
+    let query = supabase.from('products').select('*');
 
-    if(is_fav) {query = query.eq('is_favorite', is_fav);}
+    if (business_id) {
+        query = query.eq('business_id', business_id);
+    }
+
+    if (typeof is_fav === 'boolean') {
+        query = query.eq('is_favorite', is_fav);
+    }
+
     const {data, error} = await query;
 
     if (error) {throw new Error(`Error fetching products: ${error.message}`);}
@@ -208,6 +215,37 @@ export async function fetchProducts(business_id?: string, is_fav?: boolean): Pro
     }));
 
     return products;
+}
+
+/**
+ * Fetch products with the same name across all businesses for comparison.
+ *
+ * @param productName name of the product/service to compare
+ * @returns list of matching products with minimal business info attached
+ */
+export async function fetchComparableProducts(productName: string): Promise<any[] | null> {
+    const { data, error } = await supabase
+        .from('products')
+        .select(`
+            id,
+            product_name,
+            description,
+            images,
+            price,
+            business_id,
+            businesses (
+                id,
+                name,
+                logo_url
+            )
+        `)
+        .ilike('product_name', productName);
+
+    if (error) {
+        throw new Error(`Error fetching comparable products: ${error.message}`);
+    }
+
+    return data || null;
 }
 
 /**
@@ -259,9 +297,6 @@ export async function insertProduct(product: Product, imageFile?: File): Promise
     }); 
 
     if(error){throw new Error(`Error inserting product: ${error.message}`);}
-
-    // Recalculate price range from all products to ensure accuracy
-    await recalculatePriceRange(product.business_id);
 }
 
 /**
@@ -284,9 +319,6 @@ export async function updateProduct(product: Product): Promise<void> {
     const {error: uploadError} = await supabase.storage.from('products').upload(fileName, product.image); 
     if(error){throw new Error(`Error updating product: ${error.message}`);}
     if(uploadError){throw new Error(`Error uploading product image: ${uploadError.message}`);}
-
-    // Recalculate price range from all products to ensure accuracy
-    await recalculatePriceRange(product.business_id);
 }
 
 /**
@@ -314,11 +346,6 @@ export async function deleteProduct(productId: string): Promise<void> {
 
     if(deleteImageError){throw new Error(`Error deleting product image: ${deleteImageError.message}`);}
     if(error){throw new Error(`Error deleting product: ${error.message}`);}
-
-    // Recalculate price range from remaining products
-    if (businessId) {
-        await recalculatePriceRange(businessId);
-    }
 }
 
 /**

--- a/src/lib/data/utils.ts
+++ b/src/lib/data/utils.ts
@@ -202,13 +202,13 @@ export async function fetchProducts(business_id?: string, is_fav?: boolean): Pro
             name: product.product_name,
             business_id: product.business_id,
             description: product.description,
-            images: product.images,
+            image: product.images ?? undefined,
             price: Number(product.price),
             rating: product.rating ? Number(product.rating) : null,
             tags: product.tags,
             is_fav: product.is_favorite,
             is_service: product.is_service,
-            duration: product.duration,
+            duration: product.duration ?? "",
             reviews: product.reviews || null,
             user_views: Number(product.user_views),
         }
@@ -301,24 +301,46 @@ export async function insertProduct(product: Product, imageFile?: File): Promise
 
 /**
  * Update an existing product in the database.
- * 
- * @param product 
+ *
+ * @param product Product data (id, business_id, etc.)
+ * @param imageFile Optional new image file to upload; if not provided, existing image URL is kept.
  * @throws Error if the update operation fails.
  */
-export async function updateProduct(product: Product): Promise<void> {
-    const fileName = `${product.id}/image/${product.image}`;
-    const {error} = await supabase.from('products').update({
-        name: product.name,
+export async function updateProduct(product: Product, imageFile?: File): Promise<void> {
+    let imagePath: string | null = product.image || null;
+
+    if (imageFile) {
+        const fileName = `${product.id}/image/${imageFile.name}`;
+        const { error: uploadError } = await supabase.storage
+            .from('products')
+            .upload(fileName, imageFile, {
+                cacheControl: '3600',
+                upsert: true,
+            });
+        if (uploadError) {
+            throw new Error(`Error uploading product image: ${uploadError.message}`);
+        }
+        const { data: imageData } = await supabase.storage
+            .from('products')
+            .getPublicUrl(fileName);
+        imagePath = imageData?.publicUrl || fileName;
+    }
+
+    const { error } = await supabase.from('products').update({
+        product_name: product.name,
         business_id: product.business_id,
         description: product.description || null,
-        images:  product.image ? `${product.business_id}/images/${product.image}` : null,
+        images: imagePath,
         price: product.price,
-        user_views: product.user_views,
+        user_views: product.user_views ?? 0,
+        is_service: product.is_service ?? false,
+        duration: product.duration || null,
+        category: product.tags?.[0] || null,
     }).eq('id', product.id);
 
-    const {error: uploadError} = await supabase.storage.from('products').upload(fileName, product.image); 
-    if(error){throw new Error(`Error updating product: ${error.message}`);}
-    if(uploadError){throw new Error(`Error uploading product image: ${uploadError.message}`);}
+    if (error) {
+        throw new Error(`Error updating product: ${error.message}`);
+    }
 }
 
 /**

--- a/src/pages/BusinessDetail.tsx
+++ b/src/pages/BusinessDetail.tsx
@@ -1,6 +1,6 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import Header from "@/components/layout/Header";
-import { fetchProducts, fetchReview, fetchEvents } from "@/lib/data/utils";
+import { fetchBusiness, fetchProducts, fetchReview, fetchEvents } from "@/lib/data/utils";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Business, Product, Review, BusinessEvent } from "@/lib/interfaces";
@@ -11,47 +11,114 @@ import Sidebar from "@/components/business/Sidebar";
 
 const BusinessDetail = () => {
   const location = useLocation();
-  const {user, profile} = useAuth();
-  const {business} = location.state as { business: Business };
+  const { id } = useParams<{ id: string }>();
+  const { user, profile } = useAuth();
+  const [business, setBusiness] = useState<Business | null>(
+    (location.state as { business?: Business })?.business ?? null
+  );
+  const [loading, setLoading] = useState(!(location.state as { business?: Business })?.business && !!id);
   const [services, setServices] = useState<Product[]>([]);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [favorites, setFavorites] = useState<Product[]>([]);
   const [events, setEvents] = useState<BusinessEvent[]>([]);
 
   useEffect(() => {
-    const getBusinessDetails = async () => {
-      const services = await fetchProducts(business.id);
-      setServices(services);
-      const reviews = await fetchReview({ business_id: business.id });
-      setReviews(reviews);
-      const events = await fetchEvents(business.id);
-      setEvents(events);
-      const favorites = await fetchProducts(business.id, true); 
-      setFavorites(favorites);
-      
-      const { error } = await supabase.from('businesses').update({ user_views: business.user_views + 1 }).eq('id', business.id);
-      if(error) {console.error("Error updating user views:", error.message);}
+    if (!id) return;
+    const loadBusiness = async () => {
+      if (business) return;
+      setLoading(true);
+      try {
+        const data = await fetchBusiness({ business_id: id });
+        if (data && data.length > 0) setBusiness(data[0]);
+      } catch (e) {
+        console.error("Error loading business:", e);
+      } finally {
+        setLoading(false);
+      }
     };
+    loadBusiness();
+  }, [id, business]);
 
-    const updateUserBehavior = async () => {
-      const newTags = business.tags ? [...profile.recent_tags.slice(business.tags.length - 1, 15), business.tags].flat() : profile.recent_tags;
-      const recentlyViewedBusinesses = profile.recently_viewed_businesses.includes(business.id) ? profile.recently_viewed_businesses : [...profile.recently_viewed_businesses, business.id];
-      const { error } = await supabase.from('profiles').update({ recent_tags: newTags, recently_viewed_businesses: recentlyViewedBusinesses }).eq('id', user.id);
-      if(error) {console.error("Error updating recent behavior:", error.message);}
-    }
+  useEffect(() => {
+    if (!business) return;
+    const getBusinessDetails = async () => {
+      const [servicesData, reviewsData, eventsData, favoritesData] = await Promise.all([
+        fetchProducts(business.id),
+        fetchReview({ business_id: business.id }),
+        fetchEvents(business.id),
+        fetchProducts(business.id, true),
+      ]);
+      setServices(servicesData ?? []);
+      setReviews(reviewsData ?? []);
+      setEvents(eventsData ?? []);
+      setFavorites(favoritesData ?? []);
 
+      const { error } = await supabase
+        .from("businesses")
+        .update({ user_views: (business.user_views || 0) + 1 })
+        .eq("id", business.id);
+      if (error) console.error("Error updating user views:", error.message);
+    };
     getBusinessDetails();
+  }, [business]);
+
+  useEffect(() => {
+    if (!business || !user || !profile) return;
+    const updateUserBehavior = async () => {
+      const recentTags = profile.recent_tags ?? [];
+      const newTags = business.tags
+        ? [...recentTags.slice(-14), business.tags].flat()
+        : recentTags;
+      const recent = profile.recently_viewed_businesses ?? [];
+      const recentlyViewedBusinesses = recent.includes(business.id)
+        ? recent
+        : [...recent, business.id];
+      const { error } = await supabase
+        .from("profiles")
+        .update({
+          recent_tags: newTags,
+          recently_viewed_businesses: recentlyViewedBusinesses,
+        })
+        .eq("id", user.id);
+      if (error) console.error("Error updating recent behavior:", error.message);
+    };
     updateUserBehavior();
-  }, []);
+  }, [business, user, profile]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Header />
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!business) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header />
+        <div className="container mx-auto px-4 py-8 text-center">
+          <p className="text-muted-foreground">Business not found.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background">
       <Header />
       <BusinessDetailHeroSection business={business} reviewsLength={reviews.length} />
-         
+
       <div className="container mx-auto px-4 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <DetailSection business={business} favorites={favorites} services={services} reviews={reviews} events={events} />
+          <DetailSection
+            business={business}
+            favorites={favorites}
+            services={services}
+            reviews={reviews}
+            events={events}
+          />
           <Sidebar business={business} />
         </div>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,12 +6,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   TrendingUp, MessageCircle,
   Eye, Heart, Star, Calendar, Settings,
-  BarChart3, Clock, Lightbulb, Store, Plus
+  BarChart3, Clock, Lightbulb, Store, Plus, Trash2
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import Header from "@/components/layout/Header";
 import { useAuth } from "@/contexts/AuthContext";
-import { fetchBusiness, fetchReview, fetchProducts, fetchEvents } from "@/lib/data/utils";
+import { fetchBusiness, fetchReview, fetchProducts, fetchEvents, deleteProduct } from "@/lib/data/utils";
 import { Business, Review, Product, BusinessEvent } from "@/lib/interfaces";
 import { supabase } from "@/integrations/supabase/client";
 import { AddProduct } from "@/components/business/Product";
@@ -34,6 +34,19 @@ const Dashboard = () => {
     favorites: 0,
     avgRating: 0,
   });
+
+  const handleDeleteProduct = async (productId: string) => {
+    if (!window.confirm("Are you sure you want to delete this product/service?")) {
+      return;
+    }
+    try {
+      await deleteProduct(productId);
+      await loadBusinessData();
+    } catch (error) {
+      console.error("Error deleting product:", error);
+      alert("Failed to delete product/service. Please try again.");
+    }
+  };
 
   useEffect(() => {
     if (!loading && !user) {
@@ -321,7 +334,10 @@ const Dashboard = () => {
                         </div>
                       ) : (
                         products.map((product) => (
-                          <div key={product.id} className="flex items-center justify-between p-4 border border-border rounded-lg">
+                          <div
+                            key={product.id}
+                            className="flex items-center justify-between p-4 border border-border rounded-lg"
+                          >
                             <div className="flex items-center gap-4">
                               {product.image && (
                                 <img
@@ -333,10 +349,14 @@ const Dashboard = () => {
                               <div>
                                 <div className="flex items-center gap-2">
                                   <p className="font-semibold text-foreground">{product.name}</p>
-                                  <Badge variant="outline">{product.is_service ? "Service" : "Product"}</Badge>
+                                  <Badge variant="outline">
+                                    {product.is_service ? "Service" : "Product"}
+                                  </Badge>
                                 </div>
                                 {product.description && (
-                                  <p className="text-sm text-muted-foreground mt-1">{product.description}</p>
+                                  <p className="text-sm text-muted-foreground mt-1">
+                                    {product.description}
+                                  </p>
                                 )}
                                 <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
                                   <span>${product.price.toFixed(2)}</span>
@@ -344,6 +364,15 @@ const Dashboard = () => {
                                 </div>
                               </div>
                             </div>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="ml-4"
+                              onClick={() => handleDeleteProduct(product.id)}
+                              title="Delete product/service"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
                           </div>
                         ))
                       )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   TrendingUp, MessageCircle,
   Eye, Heart, Star, Calendar, Settings,
-  BarChart3, Clock, Lightbulb, Store, Plus, Trash2
+  BarChart3, Clock, Lightbulb, Store, Plus, Trash2, Pencil
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import Header from "@/components/layout/Header";
@@ -14,7 +14,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { fetchBusiness, fetchReview, fetchProducts, fetchEvents, deleteProduct } from "@/lib/data/utils";
 import { Business, Review, Product, BusinessEvent } from "@/lib/interfaces";
 import { supabase } from "@/integrations/supabase/client";
-import { AddProduct } from "@/components/business/Product";
+import { AddProduct, EditProduct } from "@/components/business/Product";
 import { AddEvent } from "@/components/business/Event";
 import Footer from "@/components/layout/Footer";
 
@@ -27,6 +27,7 @@ const Dashboard = () => {
   const [events, setEvents] = useState<BusinessEvent[]>([]);
   const [loadingBusiness, setLoadingBusiness] = useState(true);
   const [addProductOpen, setAddProductOpen] = useState(false);
+  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [addEventOpen, setAddEventOpen] = useState(false);
   const [stats, setStats] = useState({
     views: 0,
@@ -364,15 +365,24 @@ const Dashboard = () => {
                                 </div>
                               </div>
                             </div>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              className="ml-4"
-                              onClick={() => handleDeleteProduct(product.id)}
-                              title="Delete product/service"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                            <div className="flex items-center gap-2 ml-4">
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => setEditingProduct(product)}
+                                title="Edit product/service"
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => handleDeleteProduct(product.id)}
+                                title="Delete product/service"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
                           </div>
                         ))
                       )}
@@ -517,6 +527,13 @@ const Dashboard = () => {
             businessId={business.id}
             open={addProductOpen}
             onOpenChange={setAddProductOpen}
+            onSuccess={loadBusinessData}
+          />
+          <EditProduct
+            businessId={business.id}
+            product={editingProduct}
+            open={!!editingProduct}
+            onOpenChange={(open) => !open && setEditingProduct(null)}
             onSuccess={loadBusinessData}
           />
           <AddEvent


### PR DESCRIPTION
Refactor / design rationale
Constraint / problem: Business owners need a simple way to see whether profile traffic is improving or slipping, not only a single all-time view count. The dashboard also surfaces which catalog items get the most attention, which is a form of relative comparison across products (by user_views).

Violation / gap: Putting ad-hoc Supabase queries, error strings, and chart state only inside the page would mix data access, result typing, and presentation in one component, which works for a prototype but scales poorly and makes errors and empty states harder to handle consistently.

Goal: Apply separation of concerns: keep typed, reusable fetch logic in the data layer and small, testable result types (InsightsResult<T>) so the dashboard can branch on ok and show user-facing errors without duplicating Supabase error handling.

Solution:

Data: fetchProfileViewPeriodComparison in src/lib/data/utils.ts — counts views in business_profile_view_events for the recent window (last 30 days) vs the previous window (days 31–60), returns InsightsResult<ViewPeriodComparison>.
Types / helpers: ViewPeriodComparison, InsightsResult, okResult / errResult, toUserFacingError in src/lib/dashboard/storefrontInsights.ts.
UI: src/pages/Dashboard.tsx loads comparison data with other insights in loadBusinessData, sets viewTrend, and useMemo builds insight cards (e.g. “30-day momentum” with percent change vs prior period, or copy when the prior window has no baseline).
Old vs new (adjust to your real diff):

Before
(Prototype) Only static or aggregate stats, no period-over-period signal
Inline queries in the page

After
Period comparison + chart range tabs + insight cards
fetchProfileViewPeriodComparison + shared InsightsResult pattern

AI usage summary (VIBE log)
Tooling: Cursor Composer (or Agent), as required by your course.

Prompt 1 (Planner):
“Review Dashboard.tsx and src/lib/data/utils.ts. Plan how to add a 30-day vs prior 30-day profile view comparison using business_profile_view_events, with a typed InsightsResult and clear error handling. Do not block the rest of the dashboard if this fetch fails.”

Prompt 2 (Coder):
“Implement fetchProfileViewPeriodComparison(businessId) returning { ok: true, data: { recent, previous } } or { ok: false, error }. Wire it into the dashboard load path and add insight card copy for up/down percent and edge cases (no data, previous period zero).”

Human verification:

Issue found: AI assumed wrong column names / swallowed errors / wrong date boundaries.
Human fix: aligned windows to true calendar 30-day bands, surfaced Supabase errors in insightsError, or fixed division-by-zero when previous === 0.
Refinement: renamed state for clarity, moved types to storefrontInsights.ts, or adjusted card wording for accessibility.)

Verification and testing
Manual tests:


 Logged-in business owner opens Dashboard; Storefront insights loads without a full-page break if comparison fails (alert shows, rest of page usable).

 With view events in both windows, “30-day momentum” shows percent change and both counts; icon reflects up vs down.

 With views only in the recent window and previous = 0, card shows “30-day views” copy (no bogus infinite percent). (Matches insightCards logic around previous > 0.)

 Profile views chart still respects Last month / 6 months / Last year tabs and shows chart/empty/error states correctly.

 Most popular items list still ranks products by user_views when catalog has items
